### PR TITLE
DPDK: Add netns support to ethdev library

### DIFF
--- a/drivers/net/tap/meson.build
+++ b/drivers/net/tap/meson.build
@@ -14,7 +14,7 @@ sources = files(
         'tap_tcmsgs.c',
 )
 
-deps = ['bus_vdev', 'gso', 'hash']
+deps = ['bus_vdev', 'gso', 'hash', 'rte_ethdev']
 
 cflags += '-DTAP_MAX_QUEUES=16'
 

--- a/lib/ethdev/ethdev_driver.h
+++ b/lib/ethdev/ethdev_driver.h
@@ -97,6 +97,7 @@ struct rte_eth_dev_owner;
  */
 struct rte_eth_dev_data {
 	char name[RTE_ETH_NAME_MAX_LEN]; /**< Unique identifier name */
+	char netns[RTE_ETH_NETNS_MAX_LEN]; /** The netns the interface is residing **/
 
 	void **rx_queues; /**< Array of pointers to Rx queues */
 	void **tx_queues; /**< Array of pointers to Tx queues */

--- a/lib/ethdev/meson.build
+++ b/lib/ethdev/meson.build
@@ -17,6 +17,7 @@ sources = files(
         'sff_8079.c',
         'sff_8472.c',
         'sff_8636.c',
+        'rte_ethdev_netns.c',
 )
 
 headers = files(
@@ -31,6 +32,7 @@ headers = files(
         'rte_mtr_driver.h',
         'rte_tm.h',
         'rte_tm_driver.h',
+        'rte_ethdev_netns.h',
 )
 
 indirect_headers += files(

--- a/lib/ethdev/rte_ethdev.h
+++ b/lib/ethdev/rte_ethdev.h
@@ -174,6 +174,7 @@ extern "C" {
 
 #include "rte_ethdev_trace_fp.h"
 #include "rte_dev_info.h"
+#include "rte_ethdev_netns.h"
 
 extern int rte_eth_dev_logtype;
 

--- a/lib/ethdev/rte_ethdev_netns.c
+++ b/lib/ethdev/rte_ethdev_netns.c
@@ -1,0 +1,86 @@
+#include <fcntl.h>
+#include <unistd.h>
+#include <errno.h>
+#include <rte_log.h>
+
+#include "ethdev_driver.h"
+#include "rte_ethdev_netns.h"
+
+#define NETNS_STRING_LEN (RTE_ETH_NETNS_MAX_LEN + 64)
+
+int32_t rte_ethdev_enter_netns(int32_t ns)
+{
+	int32_t ret = -1;
+	int32_t origNs = open("/proc/thread-self/ns/net", O_RDONLY | O_CLOEXEC);
+	if (origNs < 0) {
+		RTE_ETHDEV_LOG(ERR, "open returned an error when accessing self netns %i," \
+							"errno:%i\n",ns, errno);
+		return origNs;
+	}
+
+	ret = setns(ns,0);
+	if (ret < 0)
+	{
+		RTE_ETHDEV_LOG(ERR, "setns returned an error when entering netns %i," \
+							"errno:%i\n",ns, errno);
+		return ret;
+	}
+	return origNs;
+}
+
+int32_t rte_ethdev_switch_netns(char * netns, int32_t * deviceNS, int32_t * originalNS)
+{
+	char ns[NETNS_STRING_LEN];
+	int32_t local_deviceNS = -1;
+	int32_t local_originalNS = -1;
+
+	if (!netns[0])
+		return -1;
+
+	snprintf(ns, NETNS_STRING_LEN, "/var/run/netns/%s", netns);
+	local_deviceNS = open(ns, O_RDONLY | O_CLOEXEC);
+	if (local_deviceNS < 0)
+		return -1;
+	*deviceNS = local_deviceNS;
+	local_originalNS = rte_ethdev_enter_netns(local_deviceNS);
+	if (local_originalNS < 0)
+		return -1;
+	*originalNS = local_originalNS;
+	return 0;
+}
+
+int32_t rte_ethdev_exit_netns(int32_t current_netns, int32_t intended_netns)
+{
+	if (intended_netns < 0)
+		return -1;
+	if (setns(intended_netns, 0) < 0)
+	{
+		RTE_ETHDEV_LOG(ERR, "setns returned an error when exiting netns %i &" \
+							"entering netns %i, errno:%i\n",
+							current_netns, intended_netns, errno);
+		return -1;
+	}
+	close(current_netns);
+	close(intended_netns);
+	return 0;
+}
+
+int32_t
+rte_ethdev_netns_get(uint16_t port_id, char *netns)
+{
+	struct rte_eth_dev *dev;
+
+	RTE_ETH_VALID_PORTID_OR_ERR_RET(port_id, -ENODEV);
+	dev = &rte_eth_devices[port_id];
+
+	if (netns == NULL) {
+		RTE_ETHDEV_LOG(ERR,
+			"Cannot get ethdev port %u configuration to NULL\n",
+			port_id);
+		return -EINVAL;
+	}
+
+	memcpy(netns, dev->data->netns, RTE_ETH_NETNS_MAX_LEN);
+
+	return 0;
+}

--- a/lib/ethdev/rte_ethdev_netns.h
+++ b/lib/ethdev/rte_ethdev_netns.h
@@ -1,0 +1,71 @@
+#pragma once
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define RTE_ETH_NETNS_MAX_LEN (64)
+
+/**
+ * Changes the network namespace
+ *
+ * This function changes the current network namespace to a given one
+ * on the last iteration (i.e. when no more matching port is found).
+ *
+ * It is safe to call this function twice; it will do nothing more.
+ *
+ * @param ns
+ *   Fd to the network namespace intended to be opened
+ * @return
+ *   Fd to the current network namespace or -1 in case of error
+ */
+int32_t rte_ethdev_enter_netns(int32_t ns);
+
+/**
+ * Switches between network namespaces
+ *
+ * Given a network namespace as string, opens the current network namespace
+ * and also the destination network namespace
+ * @param netns
+ *   String that identifies the destination network namespace
+ * @param deviceNS
+ *   Pointer to save the fd of the netns to be opened
+ * @param originalNS
+ *   Pointer to save the fd of the current netns
+ * @return
+ *   0 if success
+ *   -1 if error
+ */
+int32_t rte_ethdev_switch_netns(char * netns, int32_t * deviceNS, int32_t * originalNS);
+
+/**
+ * Exits a network namespace
+ *
+ * Given a network namespace as string, opens the current network namespace
+ * and also the destination network namespace
+ * @param current_netns
+ *   Fd for the current netns that will be exited. Fd will be closed in this function
+ * @param intended_netns
+ *   Fd to the destination network namespace. Fd will be closed in this function
+ * @return
+ *   0 if success
+ *   -1 if error
+ */
+int32_t rte_ethdev_exit_netns(int32_t current_netns, int32_t intended_netns);
+
+/**
+ * Returnes a port's network namespace
+ *
+ * Returns installed netns of a port if given at startup
+ * @param port_id
+ *   Port id to retrieve the network namespace
+ * @param netns
+ *   String to save the network namespace for the given port
+ * @return
+ *   0 if success
+ *   -EINVAL if no netns found
+ */
+int32_t rte_ethdev_netns_get(uint16_t port_id, char *netns);
+
+#ifdef __cplusplus
+}
+#endif

--- a/lib/ethdev/version.map
+++ b/lib/ethdev/version.map
@@ -135,6 +135,7 @@ DPDK_23 {
 	rte_flow_pick_transfer_proxy;
 	rte_flow_query;
 	rte_flow_validate;
+	rte_ethdev_netns_get;
 
 	local: *;
 };


### PR DESCRIPTION
*Add netns support to the ethdev library
*Parse a new input param when using the tap driver: netns.