### PR TITLE
DPDK: Fix tap build

### DIFF
--- a/drivers/net/tap/meson.build
+++ b/drivers/net/tap/meson.build
@@ -14,7 +14,7 @@ sources = files(
         'tap_tcmsgs.c',
 )
 
-deps = ['bus_vdev', 'gso', 'hash', 'rte_ethdev']
+deps = ['bus_vdev', 'gso', 'hash']
 
 cflags += '-DTAP_MAX_QUEUES=16'
 

--- a/lib/ethdev/version.map
+++ b/lib/ethdev/version.map
@@ -136,6 +136,8 @@ DPDK_23 {
 	rte_flow_query;
 	rte_flow_validate;
 	rte_ethdev_netns_get;
+        rte_ethdev_switch_netns;
+        rte_ethdev_exit_netns;
 
 	local: *;
 };


### PR DESCRIPTION
This PR fixes the tap driver compilation

The nf_builder image would not build the tap driver. This was caused by a missing dependency when building the tap driver. 