### PR TITLE
DPDK: Collect replay window size & auth errror stats

### DIFF
--- a/lib/ipsec/esp_inb.c
+++ b/lib/ipsec/esp_inb.c
@@ -388,6 +388,7 @@ esp_inb_pkt_prepare(const struct rte_ipsec_session *ss, struct rte_mbuf *mb[],
 		} else {
 			dr[i - k] = i;
 			rte_errno = -rc;
+			mb[i]->dynfield1[0] = -rc;
 		}
 	}
 

--- a/lib/ipsec/rte_ipsec_group.h
+++ b/lib/ipsec/rte_ipsec_group.h
@@ -97,9 +97,11 @@ rte_ipsec_pkt_crypto_group(const struct rte_crypto_op *cop[],
 		ns = cop[i]->sym[0].session;
 
 		m->ol_flags |= RTE_MBUF_F_RX_SEC_OFFLOAD;
-		if (cop[i]->status != RTE_CRYPTO_OP_STATUS_SUCCESS)
+		if (cop[i]->status != RTE_CRYPTO_OP_STATUS_SUCCESS) {
+			if (cop[i]->status & RTE_CRYPTO_OP_STATUS_AUTH_FAILED)
+				m->dynfield1[0] = RTE_CRYPTO_OP_STATUS_AUTH_FAILED;
 			m->ol_flags |= RTE_MBUF_F_RX_SEC_OFFLOAD_FAILED;
-
+		}
 		/* no valid session found */
 		if (ns == NULL) {
 			dr[k++] = m;


### PR DESCRIPTION
Collect replay window size errors so we can collect stats on it. 
Collect if the authentication step failed so we can collect stats on it.